### PR TITLE
Add requirement to publish papers and minutes

### DIFF
--- a/Core/Meetings.md
+++ b/Core/Meetings.md
@@ -4,7 +4,15 @@ The Core Working Group shall hold meetings once every month.
 The meetings shall be conducted electronically, and according to [Robert's Rules of Order](http://www.rulesonline.com/). 
 An Agenda for the meeting shall be made available to Working Group Members by the Chair of the Core Working Group at least 48 hours prior to the meeting. 
 A transcription of the results of the meeting shall be made available to Working Group Members within 48 hours following the meeting.
-Quorum for meetings of Core Working Group shall be 2/3s of its membership. 
+Quorum for meetings of Core Working Group shall be 2/3s of its membership.
+All papers reviewed and approved during the meeting shall be made available by the Responsible Working Group Chair in the WG-Papers responsitory, this requirement may be waived at the discretion of the Project Manager for papers which change the Governence Rules, or Technical Report papers which are deemend unecessary to publish.
+The transcription from the previous meeting shall be voted on to approve during each subsequent meeting, and if approved, shall be made available in the WG-Core-Minutes repository by the Project Manager or a designated substitute. 
+The Responsible Working Group Chair for a paper submitted to the Core Working Group shall be either:
+* The chair of the Working Group which originates the paper, if the paper was originated in a single Working Group other than the Core Working Group 
+* The chair of the Working Group which originates the paper and for which the paper is most closely associated with the responsibilities of, if there is such a Working Group, and only one such Working Group
+* The chair of any Working Group which originates the paper, at the consensus of all such Working Group Chairs if none of such Working Groups are the Core Working Group. 
+* The Project Manager or a designated substitute for all other papers (IE. papers which were originated in the Core Working Group)
+* All papers which seak to ammend the governance of the Laser Language shall be deemed to have originated in the Core Working Group, for the purposes of determining the Responsible Working Group Chair.
 
 A *simple majority* is required to approve changes to the language or library
 


### PR DESCRIPTION
Approved papers, both Technical Specifications and Technical Reports, should be published so that they are available to users of the Laser Language as well as Implementors. Similar thing for the Minutes.