### PR TITLE
Add to Project Manager Ineligibility clause

### DIFF
--- a/Core/ProjectManager.md
+++ b/Core/ProjectManager.md
@@ -12,4 +12,4 @@ Additionally, the project manager is granted the following authority and respons
 
 The Project Manager must have the confidence of the Core Working Group. A *simple-majority* vote of the Core Working Group may remote a Project Manager on the basis of non-confidence. 
 
-A person who is chair of any Working Group is ineligible to be the Project Manager, and the Project Manager is ineligible to chair any Working Group, except for the Core Working Group. A person who is otherwise ineligible to be a Working Group chair, is also ineligible to be the Project Manager.
+A person who is chair of any Working Group is ineligible to be the Project Manager, and the Project Manager is ineligible to chair any Working Group, except for the Core Working Group. A person who is otherwise ineligible to be a Working Group chair is also ineligible to be the Project Manager.

--- a/Core/ProjectManager.md
+++ b/Core/ProjectManager.md
@@ -12,4 +12,4 @@ Additionally, the project manager is granted the following authority and respons
 
 The Project Manager must have the confidence of the Core Working Group. A *simple-majority* vote of the Core Working Group may remote a Project Manager on the basis of non-confidence. 
 
-A person who is chair of any Working Group is inelligable to be the Project Manager, and the Project Manager is inelligable to chair any Working Group, except for the Core Working Group.
+A person who is chair of any Working Group is ineligible to be the Project Manager, and the Project Manager is ineligible to chair any Working Group, except for the Core Working Group. A person who is otherwise ineligible to the a Working Group chair, is also ineligible to be the Project Manager.

--- a/Core/ProjectManager.md
+++ b/Core/ProjectManager.md
@@ -12,4 +12,4 @@ Additionally, the project manager is granted the following authority and respons
 
 The Project Manager must have the confidence of the Core Working Group. A *simple-majority* vote of the Core Working Group may remote a Project Manager on the basis of non-confidence. 
 
-A person who is chair of any Working Group is ineligible to be the Project Manager, and the Project Manager is ineligible to chair any Working Group, except for the Core Working Group. A person who is otherwise ineligible to the a Working Group chair, is also ineligible to be the Project Manager.
+A person who is chair of any Working Group is ineligible to be the Project Manager, and the Project Manager is ineligible to chair any Working Group, except for the Core Working Group. A person who is otherwise ineligible to be a Working Group chair, is also ineligible to be the Project Manager.


### PR DESCRIPTION
With #6 and #7, it is possible for a person to become ineligible to chair a Working Group. However, it is ambiguous whether or not this would apply to the Project Manager. This proposed amendment corrects it by stating that anyone ineligible to be a Working Group chair is also ineligible to be the Project Manager, except when the ineligibility is caused by holding the position. 