### PR TITLE
Require Working Group chairs to maintain a list of Group Members

### DIFF
--- a/Groups.md
+++ b/Groups.md
@@ -24,6 +24,7 @@ The chair has the following responsibilities:
 * Providing on a method of communication, discussion, and voting for papers recieved by the group
 * Providing a method to recieve papers from outside the group, and originate papers from within the group.
 * Submitting papers voted on by their working group to the core working group. 
+* Maitain a list, available to at least the Project Manager and Working Group Members upon request, of the membership of the working group
 
 The chair of each working group needs the confidence of the members. A majority vote of the working group may remove the sitting chair. These chairs are repsonsible for providing a system which allows working group members to issue votes of non-confidence. 
 


### PR DESCRIPTION
Presently, no list of members is available, so the actual membership of working groups is vague. This may affect how working groups make decisions. While the method of voting is generally up to the Working Group chair, non-confidence votes are defined by Governance, and dependent on the membership of a Working Group. 
This amendment will require Working Group chairs maintain a list of the membership of the working group (though it does not impose any requirements on the membership, or admittance) and make it available to any member of the working group or the project manager upon request. 