### PR TITLE
Meeting Changes and Clarifications

### DIFF
--- a/Core/Meetings.md
+++ b/Core/Meetings.md
@@ -1,7 +1,7 @@
 # Core Working Group Meetings
 
-The Core Working Group shall hold meetings once every month. 
-The meetings shall be conducted electronically, and according to [Robert's Rules of Order](http://www.rulesonline.com/). 
+The Core Working Group shall hold meetings at least once every month, at a date and time established by the Project Manager. 
+The meetings shall be conducted electronically, in such a manner as established by the Project Manager, and shall be conducted according to [Robert's Rules of Order (newly revised)](http://www.rulesonline.com/). 
 An Agenda for the meeting shall be made available to Working Group Members by the Chair of the Core Working Group at least 48 hours prior to the meeting. 
 A transcription of the results of the meeting shall be made available to Working Group Members within 48 hours following the meeting.
 Quorum for meetings of Core Working Group shall be 2/3s of its membership.
@@ -19,3 +19,9 @@ A *simple majority* is required to approve changes to the language or library
 A *two-thirds majority* is required to approve changes to the governance of the language or library. 
 
 A *two-thirds majority* is required to establish a new working group. 
+
+## Additional Meetings
+
+The Project Manager may convene additional meetings under all of the above rules, outside of the normal monthly meeting, with reasonable cause. A majority of the Core Working Group may request that the Project Manager convene such a meeting. 
+
+Additionally, when it is necessary for the proper excercise of power granted by this Governance, and when 3/4s of the Core Working Group agree, the Project Manager may convene an emergency meeting to resolve issues in the proper excercise of such power. Such emergency meetings dispose of the requirements of an agenda and minutes, and the results of the meeting may be discussed in the subsequent standard meeting of the Core Working Group, or included in the transcription of the previous meeting if the issue arrose from that previous meeting. 

--- a/Core/Meetings.md
+++ b/Core/Meetings.md
@@ -4,7 +4,7 @@ The Core Working Group shall hold meetings at least once every month, at a date 
 The meetings shall be conducted electronically, in such a manner as established by the Project Manager, and shall be conducted according to [Robert's Rules of Order (newly revised)](http://www.rulesonline.com/). 
 An Agenda for the meeting shall be made available to Working Group Members by the Chair of the Core Working Group at least 48 hours prior to the meeting. 
 A transcription of the results of the meeting shall be made available to Working Group Members within 48 hours following the meeting.
-Quorum for meetings of Core Working Group shall be 2/3s of its membership.
+Quorum for meetings of Core Working Group shall be 2/3s of its membership. If it is not possible to convene a quorum at a regular meeting where the Project Manager attempts to do so in Good Faith, the meeting shall be considered to have been held, though no business was conducted.
 All papers reviewed and approved during the meeting shall be made available by the Responsible Working Group Chair in the WG-Papers responsitory, this requirement may be waived at the discretion of the Project Manager for papers which change the Governence Rules, or Technical Report papers which are deemend unecessary to publish.
 The transcription from the previous meeting shall be voted on to approve during each subsequent meeting, and if approved, shall be made available in the WG-Core-Minutes repository by the Project Manager or a designated substitute. 
 The Responsible Working Group Chair for a paper submitted to the Core Working Group shall be either:

--- a/Core/Meetings.md
+++ b/Core/Meetings.md
@@ -1,12 +1,13 @@
 # Core Working Group Meetings
 
 The Core Working Group shall hold meetings at least once every month, at a date and time established by the Project Manager. 
-The meetings shall be conducted electronically, in such a manner as established by the Project Manager, and shall be conducted according to [Robert's Rules of Order (newly revised)](http://www.rulesonline.com/). 
-An Agenda for the meeting shall be made available to Working Group Members by the Chair of the Core Working Group at least 48 hours prior to the meeting. 
+The meetings shall be conducted electronically, in such a manner as established by the Project Manager, and shall be conducted according to [Robert's Rules of Order (newly revised)](http://www.rulesonline.com/), or some other rules of order which may be established by the Core Working Group and described by Technical Report. 
+An Agenda for the meeting shall be made available to Working Group Members by Project Manager at least 48 hours prior to the meeting. 
 A transcription of the results of the meeting shall be made available to Working Group Members within 48 hours following the meeting.
-Quorum for meetings of Core Working Group shall be 2/3s of its membership. If it is not possible to convene a quorum at a regular meeting where the Project Manager attempts to do so in Good Faith, the meeting shall be considered to have been held, though no business was conducted.
+Quorum for meetings of Core Working Group shall be 2/3s of its membership. No meeting shall be convened, or conduct any business further than adjourning the meeting, or appointing a speaker for solely that purpose, without a quorum present. 
+If it is not possible to convene a quorum at a regular meeting where the Project Manager attempts to do so in Good Faith, the meeting shall be considered to have been held, as though the meeting was convened, and immediately adjourned by a quorum. 
 All papers reviewed and approved during the meeting shall be made available by the Responsible Working Group Chair in the WG-Papers responsitory, this requirement may be waived at the discretion of the Project Manager for papers which change the Governence Rules, or Technical Report papers which are deemend unecessary to publish.
-The transcription from the previous meeting shall be voted on to approve during each subsequent meeting, and if approved, shall be made available in the WG-Core-Minutes repository by the Project Manager or a designated substitute. 
+The transcription from the previous meeting at which a quorum was present shall be voted on to approve during each subsequent meeting, and if approved, shall be made available in the WG-Core-Minutes repository by the Project Manager or a designated substitute. 
 The Responsible Working Group Chair for a paper submitted to the Core Working Group shall be either:
 * The chair of the Working Group which originates the paper, if the paper was originated in a single Working Group other than the Core Working Group 
 * The chair of the Working Group which originates the paper and for which the paper is most closely associated with the responsibilities of, if there is such a Working Group, and only one such Working Group
@@ -22,6 +23,6 @@ A *two-thirds majority* is required to establish a new working group.
 
 ## Additional Meetings
 
-The Project Manager may convene additional meetings under all of the above rules, outside of the normal monthly meeting, with reasonable cause. A majority of the Core Working Group may request that the Project Manager convene such a meeting. 
+The Project Manager may convene additional meetings under all of the above rules, outside of the normal monthly meeting, for reasonable cause. A majority of the Core Working Group may request that the Project Manager convene such a meeting, for reasonable cause. 
 
-Additionally, when it is necessary for the proper excercise of power granted by this Governance, and when 3/4s of the Core Working Group agree, the Project Manager may convene an emergency meeting to resolve issues in the proper excercise of such power. Such emergency meetings dispose of the requirements of an agenda and minutes, and the results of the meeting may be discussed in the subsequent standard meeting of the Core Working Group, or included in the transcription of the previous meeting if the issue arrose from that previous meeting. 
+Additionally, when 2/3s of the Core Working Group agree, the Project Manager may convene an emergency meeting to resolve serious issues in the excercise of Governance Authority. Such emergency meetings may dispose of the requirements of an agenda and minutes, and the results of the meeting may be discussed in the subsequent standard meeting of the Core Working Group, or included in the transcription of the previous meeting if the issue arrose from that previous meeting. An emergency meeting shall conduct no business further than convening and adjourning the meeting, appointing a speaker if necessary, and any further business necessary to resolve the issues above.


### PR DESCRIPTION
Strictly under Governance, the only meetings which can be held by core are the Monthly meetings. This seeks to reduce that to only requiring that the Monthly meeting be held, and allowing the Project Manager to convene additional meetings. Additionally, in certain circumstances, the Project Manager can convene emergency meetings that are without the agenda or transcription requirements. 
Also adds a few clarifications for edge cases, such as what happens when the Project Manager cannot convene a regular meeting.